### PR TITLE
P2 2224 - Pentest fix to include 'secure' attribute in cookie

### DIFF
--- a/src/SFA.DAS.ProviderRequestApprenticeTraining.Web/Startup.cs
+++ b/src/SFA.DAS.ProviderRequestApprenticeTraining.Web/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -36,6 +37,8 @@ namespace SFA.DAS.ProviderRequestApprenticeTraining.Web
             {
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.None;
+                options.HttpOnly = HttpOnlyPolicy.Always;
+                options.Secure = CookieSecurePolicy.Always;
             });
 
             services.AddOpenTelemetryRegistration(_configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]!);


### PR DESCRIPTION
Added pentest fix to include 'secure' attribute within a cookie to address a security vulnerability.